### PR TITLE
Add root keys to single article and single comment payloads

### DIFF
--- a/src/conduit/events.cljs
+++ b/src/conduit/events.cljs
@@ -183,7 +183,7 @@
                                              (endpoint "articles" (:slug params))   ;; endpoint - one with :slug to update
                                              (endpoint "articles"))                 ;; and another to insert
                           :headers         (auth-header db)                         ;; get and pass user token obtained during login
-                          :params          (:article params)
+                          :params          {:article (:article params)}
                           :format          (json-request-format)                    ;; make sure we are doing request format wiht json
                           :response-format (json-response-format {:keywords? true}) ;; json response and all keys to keywords
                           :on-success      [:upsert-article-success]                ;; trigger upsert-article-success event
@@ -302,7 +302,7 @@
              :http-xhrio {:method          :post
                           :uri             (endpoint "articles" (:active-article db) "comments") ;; evaluates to "api/articles/:slug/comments"
                           :headers         (auth-header db)                                      ;; get and pass user token obtained during login
-                          :params          body
+                          :params          {:comment body}
                           :format          (json-request-format)                                 ;; make sure we are doing request format wiht json
                           :response-format (json-response-format {:keywords? true})              ;; json response and all keys to keywords
                           :on-success      [:post-comment-success]                               ;; trigger get-articles-success

--- a/src/conduit/views.cljs
+++ b/src/conduit/views.cljs
@@ -2,7 +2,7 @@
   (:require [reagent.core  :as reagent]
             [conduit.router :refer [url-for set-token!]]
             [re-frame.core :refer [subscribe dispatch]]
-            [clojure.string :as str :refer [trim split]]))
+            [clojure.string :as str :refer [trim split join]]))
 
 ;; -- Helpers -----------------------------------------------------------------
 ;;
@@ -387,6 +387,7 @@
 (defn editor
   []
   (let [{:keys [title description body tagList slug] :as active-article} @(subscribe [:active-article])
+        tagList (join " " tagList)
         default {:title title :description description :body body :tagList tagList}
         content (reagent/atom default)]
     (fn []


### PR DESCRIPTION
Single article and single comment should have root keys according to the [spec](https://github.com/gothinkster/realworld/tree/master/api).

Now, tags, which you assigned to a post, are not stored. I also changed a bit the editor component to show tags properly.