### PR TITLE
Correct the path to main.js

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
 
     <div id="app"></div>
 
-    <script src="./js/main.js" type="text/javascript"></script>
+    <script src="/js/main.js" type="text/javascript"></script>
     <script>window.onload = function() { conduit.core.main(); }</script>
   </body>
 </html>


### PR DESCRIPTION
When refreshing page on uris other than `/`, conduit js will not be found due to relative path 